### PR TITLE
Removed the Carousel - Replaced with Cards Instead

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,93 +94,68 @@
   </section>
 
   <!-- Projects Section -->
-  <div class="row align-items-center">
-    <div class="col-12">
       <section class="container text-center" id="projects-section">
         <h2 class="display-3">My Projects</h2>
-        <div id="carouselExampleCaptions" class="carousel slide w-75" data-bs-interval="false">
-          <div class="carousel-indicators">
-            <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="0" class="active"
-              aria-current="true" aria- label="Slide 1"></button>
-            <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="1"
-              aria-label="Slide 2"></button>
-            <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="2"
-              aria-label="Slide 3"></button>
-            <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="3"
-              aria-label="Slide 4"></button>
-            <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="4"
-              aria-label="Slide 5"></button>
-            <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="5"
-              aria-label="Slide 6"></button>
-          </div>
-          <div class="carousel-inner">
-            <div class="carousel-item active">
-              <img src="projectimages/hmda/hmda_overview.jpg" style="object-position:50% 25%;" class="w-100 mx-auto"
-                alt="Image of a couple completing paperwork">
-              <div class="carousel-caption">
-                <h5>HMDA: Bias in Home Mortgage Loans / June 2022 / Excel</h5>
-                <button type="button" class="btn btn-dark"><a href="hmda.html">Click Here for More Details!</a></button>
-              </div>
-            </div>
-            <div class="carousel-item">
-              <img src="projectimages/comfybunk/comfybunk_overview.jpeg" style="object-position:50% 50%;"
-                class="w-100 mx-auto" alt="Image of an upscale room">
-              <div class="carousel-caption">
-                <h5>ComfyBunk: Visualizing Business Metrics / July 2022 / Tableau</h5>
-                <button type="button" class="btn btn-dark"><a href="comfybunk.html">Click Here for More
-                    Details!</a></button>
-              </div>
-            </div>
-            <div class="carousel-item">
-              <img src="projectimages/lyft/lyft_overview.jpg" style="object-position:50% 40%;" class="w-100 mx-auto"
-                alt="Image of a Lyft Baywheels bicycle">
-              <div class="carousel-caption">
-                <h5>Lyft Baywheels: Bikeshare User Analysis / December 2022 / SQL & Tableau</h5>
-                <button type="button" class="btn btn-dark"><a href="lyft.html">Click Here for More Details!</a></button>
-              </div>
-            </div>
-            <div class="carousel-item">
-              <img src="projectimages/starbucks/starbucks_overview.jpeg" style="object-position:50% 25%;"
-                class="w-100 mx-auto" alt="Image of the Starbucks logo">
-              <div class="carousel-caption">
-                <h5>Starbucks: RFM Analysis / February 2023 / Python</h5>
-                <button type="button" class="btn btn-dark"><a href="starbucks.html">Click Here for More
-                    Details!</a></button>
-              </div>
-            </div>
-            <div class="carousel-item">
-              <img src="projectimages/intel/intel_overview.jpg" style="object-position:50% 45%;" class="w-100 mx-auto"
-                alt="Image of the Intel logo">
-              <div class="carousel-caption">
-                <h5>Intel: Build a Data Center / June 2023 / Tableau</h5>
-                <button type="button" class="btn btn-dark"><a href="intel.html">Click Here for More
-                    Details!</a></button>
-              </div>
-            </div>
-            <div class="carousel-item">
-              <img src="projectimages/grammys/grammys_overview.jpg" style="object-position:50% 35%;"
-                class="w-100 mx-auto" alt="Image of the Grammy award trophies">
-              <div class="carousel-caption">
-                <h5>Grammys: Analyzing Website Data / July 2023 / Python</h5>
-                <button type="button" class="btn btn-dark"><a href="grammys.html">Click Here for More
-                    Details!</a></button>
+        <div class="row align-items-center">
+          <div class="col-sm-12 col-md-4 d-flex justify-content-center">
+            <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
+              <img class="card-img-top" src="projectimages/hmda/hmda_overview.jpg" alt="Image of a couple completing paperwork" width=250px height=200px>
+              <div class="card-body">
+                <h5 class="card-title">HMDA</h5>
+                <p class="card-text">Excel</p>
+                <a href="hmda.html" class="btn" style="background-color:#522e92;">View Project</a>
               </div>
             </div>
           </div>
-          <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions"
-            data-bs-slide="prev">
-            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Previous</span>
-          </button>
-          <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions"
-            data-bs-slide="next">
-            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Next</span>
-          </button>
+          <div class="col-sm-12 col-md-4 d-flex justify-content-center">
+            <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
+              <img class="card-img-top" src="projectimages/lyft/lyft_overview.jpg" alt="Image of a Lyft Baywheels bicycle"
+                width=250px height=200px>
+              <div class="card-body">
+                <h5 class="card-title">Lyft Baywheels</h5>
+                <p class="card-text">SQL & Tableau</p>
+                <a href="lyft.html" class="btn" style="background-color:#522e92;">View Project</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-12 col-md-4 d-flex justify-content-center">
+            <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
+              <img class="card-img-top" src="projectimages/starbucks/starbucks_overview.jpeg"
+                alt="Image of the Starbucks logo" width=250px height=200px>
+              <div class="card-body">
+                <h5 class="card-title">Starbucks</h5>
+                <p class="card-text">Python</p>
+                <a href="starbucks.html" class="btn" style="background-color:#522e92;">View Project</a>
+              </div>
+            </div>
+          </div>
         </div>
-    </div>
-  </div>
-  </section>
+        
+        <div class="row align-items-center">
+          <div class="col-sm-12 col-md-6 d-flex justify-content-center">
+            <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
+              <img class="card-img-top" src="projectimages/intel/intel_overview.jpg" alt="Image of the Intel logo"
+                width=250px height=200px>
+              <div class="card-body">
+                <h5 class="card-title">Intel</h5>
+                <p class="card-text">Tableau</p>
+                <a href="intel.html" class="btn" style="background-color:#522e92;">View Project</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-12 col-md-6 d-flex justify-content-center">
+            <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
+              <img class="card-img-top" src="projectimages/grammys/grammys_overview.jpg"
+                alt="Image of the Grammy award trophies" width=250px height=200px>
+              <div class="card-body">
+                <h5 class="card-title">Grammys</h5>
+                <p class="card-text">Python</p>
+                <a href="grammys.html" class="btn" style="background-color:#522e92;">View Project</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
   <!-- Contact Section -->
   <div id="contact-color">

--- a/index.html
+++ b/index.html
@@ -130,9 +130,9 @@
             </div>
           </div>
         </div>
-        
+
         <div class="row align-items-center">
-          <div class="col-sm-12 col-md-6 d-flex justify-content-center">
+          <div class="col-sm-12 col-md-4 d-flex justify-content-center">
             <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
               <img class="card-img-top" src="projectimages/intel/intel_overview.jpg" alt="Image of the Intel logo"
                 width=250px height=200px>
@@ -143,7 +143,18 @@
               </div>
             </div>
           </div>
-          <div class="col-sm-12 col-md-6 d-flex justify-content-center">
+          <div class="col-sm-12 col-md-4 d-flex justify-content-center">
+            <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
+              <img class="card-img-top" src="projectimages/comfybunk/comfybunk_overview.jpeg" alt="Image of an upscale room"
+                width=250px height=200px>
+              <div class="card-body">
+                <h5 class="card-title">ComfyBunk</h5>
+                <p class="card-text">Tableau</p>
+                <a href="comfybunk.html" class="btn" style="background-color:#522e92;">View Project</a>
+              </div>
+            </div>
+          </div>
+          <div class="col-sm-12 col-md-4 d-flex justify-content-center">
             <div class="card bg-dark" style="width: 18rem; margin-bottom: 25px;">
               <img class="card-img-top" src="projectimages/grammys/grammys_overview.jpg"
                 alt="Image of the Grammy award trophies" width=250px height=200px>


### PR DESCRIPTION
The carousel was annoying to use to look at my projects because you could only see them one at a time. I think having them in cards will be better because someone could take a brief glance at the technologies used in each project and decide which one to look at rather than have to scroll through them all. I have some more editing to do on them later but this is good for now.